### PR TITLE
Improve errors v2

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: akhellad <akhellad@student.42.fr>          +#+  +:+       +#+        */
+/*   By: agaley <agaley@student.42lyon.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/22 01:41:30 by akhellad          #+#    #+#             */
-/*   Updated: 2023/07/28 21:48:43 by akhellad         ###   ########.fr       */
+/*   Updated: 2023/07/29 00:30:29 by agaley           ###   ########lyon.fr   */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -86,17 +86,18 @@ typedef struct s_g_global
 extern t_g_global	g_global;
 int	(*init_builtins(char *str))(t_infos *infos, t_cmds_infos *cmds_infos);
 
-/* Error codes */
-# define ERR_NEWLINE 0
-# define ERR_MEMORY 1
-# define ERR_QUOTES 2
-# define ERR_PARSER 3
-# define ERR_PIPE 4
-# define ERR_FORK 5
-# define ERR_OUTFILE 6
-# define ERR_INFILE 7
-# define ERR_PATH 8
-# define ERR_PERM 9
+/*Error messages*/
+# define ERR_NEWLINE "syntax error near unexpected token 'newline'\n"
+# define ERR_MEMORY "memory error: unable to assign memory\n"
+# define ERR_QUOTES "syntax error: unable to locate closing quotation\n"
+# define ERR_PARSER "Parser problem\n"
+# define ERR_PIPE "Failed to create pipe\n"
+# define ERR_FORK "Failed to fork\n"
+# define ERR_OUTFILE "outfile: Error\n"
+# define ERR_INFILE "infile: No such file or directory\n"
+# define ERR_PATH "Path does not exist\n"
+# define ERR_PERM "Permission denied\n"
+# define ERR_ARGS "Too many arguments\n"
 
 /*main.c*/
 int				init_infos(t_infos *infos);
@@ -137,8 +138,8 @@ t_lexer			*ft_clearlexer_one(t_lexer **lexers);
 /*errors.c*/
 int				double_token_error(t_infos *infos, t_lexer *lexers, \
 								t_tokens token);
-void			parser_error(int error, t_infos *infos, t_lexer *lexers);
-int				ft_error(int error, t_infos *infos);
+void			parser_error(char *error, t_infos *infos, t_lexer *lexers);
+int				ft_error(char *error, t_infos *infos);
 int				check_pipe_errors(t_infos *infos, t_tokens token);
 
 /*redirs.c*/
@@ -194,7 +195,7 @@ size_t			find_equal(char *str);
 int				cd_built(t_infos *infos, t_cmds_infos *cmd_infos);
 
 /*env_built.c*/
-int 			env_built(t_infos *infos, t_cmds_infos *cmd_infos);
+int				env_built(t_infos *infos, t_cmds_infos *cmd_infos);
 int				pwd_built(t_infos *infos, t_cmds_infos *cmd_infos);
 
 /*exit_build.c*/

--- a/srcs/errors.c
+++ b/srcs/errors.c
@@ -3,16 +3,16 @@
 /*                                                        :::      ::::::::   */
 /*   errors.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: akhellad <akhellad@student.42.fr>          +#+  +:+       +#+        */
+/*   By: agaley <agaley@student.42lyon.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/23 09:13:07 by akhellad          #+#    #+#             */
-/*   Updated: 2023/07/28 04:19:06 by akhellad         ###   ########.fr       */
+/*   Updated: 2023/07/29 00:29:57 by agaley           ###   ########lyon.fr   */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/minishell.h"
 
-void	parser_error(int error, t_infos *infos, t_lexer *lexers)
+void	parser_error(char *error, t_infos *infos, t_lexer *lexers)
 {
 	ft_clearlexer(&lexers);
 	ft_error(error, infos);
@@ -40,29 +40,9 @@ int	double_token_error(t_infos *infos, t_lexer *lexers,
 	return (EXIT_FAILURE);
 }
 
-int	ft_error(int error, t_infos *infos)
+int	ft_error(char *message, t_infos *infos)
 {
-	if (error == ERR_NEWLINE)
-		ft_putstr_fd("syntax error near unexpected token 'newline'\n", 2);
-	else if (error == ERR_MEMORY)
-		ft_putstr_fd("memory error: unable to assign memory\n", STDERR_FILENO);
-	else if (error == ERR_QUOTES)
-		ft_putstr_fd("syntax error: unable to locate closing quotation\n",
-			STDERR_FILENO);
-	else if (error == ERR_PARSER)
-		ft_putstr_fd("Parser problem\n", STDERR_FILENO);
-	else if (error == ERR_PIPE)
-		ft_putstr_fd("Failed to create pipe\n", STDERR_FILENO);
-	else if (error == ERR_FORK)
-		ft_putstr_fd("Failed to fork\n", STDERR_FILENO);
-	else if (error == ERR_OUTFILE)
-		ft_putstr_fd("outfile: Error\n", STDERR_FILENO);
-	else if (error == ERR_INFILE)
-		ft_putstr_fd("infile: No such file or directory\n", STDERR_FILENO);
-	else if (error == ERR_PATH)
-		ft_putendl_fd("Path does not exist", STDERR_FILENO);
-	else if (error == ERR_PERM)
-		ft_putendl_fd("Permission denied", STDERR_FILENO);
+	ft_putstr_fd(message, STDERR_FILENO);
 	if (infos)
 		reset_infos(infos);
 	return (EXIT_FAILURE);

--- a/srcs/loop.c
+++ b/srcs/loop.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   loop.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: akhellad <akhellad@student.42.fr>          +#+  +:+       +#+        */
+/*   By: agaley <agaley@student.42lyon.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/22 18:19:13 by akhellad          #+#    #+#             */
-/*   Updated: 2023/07/28 04:08:12 by akhellad         ###   ########.fr       */
+/*   Updated: 2023/07/29 00:15:26 by agaley           ###   ########lyon.fr   */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,8 +23,7 @@ t_cmds_infos	*call_expand(t_infos *infos, t_cmds_infos *cmd)
 	while (cmd->redir)
 	{
 		if (cmd->redir->token != TWO_LESS)
-			cmd->redir->arg
-				= expand_str(infos, cmd->redir->arg);
+			cmd->redir->arg = expand_str(infos, cmd->redir->arg);
 		cmd->redir = cmd->redir->next;
 	}
 	cmd->redir = start;

--- a/srcs/parser.c
+++ b/srcs/parser.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parser.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: akhellad <akhellad@student.42.fr>          +#+  +:+       +#+        */
+/*   By: agaley <agaley@student.42lyon.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/23 08:19:58 by akhellad          #+#    #+#             */
-/*   Updated: 2023/07/25 22:24:12 by akhellad         ###   ########.fr       */
+/*   Updated: 2023/07/29 00:26:00 by agaley           ###   ########lyon.fr   */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@ t_cmds_infos	*init_cmd(t_parser_infos *parser_infos)
 	args_nbr = count_args(parser_infos->lexers);
 	args = ft_calloc(args_nbr + 1, sizeof(char *));
 	if (!args)
-		parser_error(1, parser_infos->infos, parser_infos->lexers);
+		parser_error(ERR_PARSER, parser_infos->infos, parser_infos->lexers);
 	tmp = parser_infos->lexers;
 	while (args_nbr > 0)
 	{

--- a/srcs/redirs.c
+++ b/srcs/redirs.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   redirs.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: akhellad <akhellad@student.42.fr>          +#+  +:+       +#+        */
+/*   By: agaley <agaley@student.42lyon.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/23 21:42:38 by akhellad          #+#    #+#             */
-/*   Updated: 2023/07/25 23:08:00 by akhellad         ###   ########.fr       */
+/*   Updated: 2023/07/29 00:27:15 by agaley           ###   ########lyon.fr   */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@ int	add_new_redirs(t_lexer *tmp, t_parser_infos *parser_infos)
 
 	node = ft_newlexer(ft_strdup(tmp->next->arg), tmp->token);
 	if (!node)
-		parser_error(1, parser_infos->infos, parser_infos->lexers);
+		parser_error(ERR_PARSER, parser_infos->infos, parser_infos->lexers);
 	ft_addlexer_back(&parser_infos->redir, node);
 	index_1 = tmp->index;
 	index_2 = tmp->next->index;


### PR DESCRIPTION
Ca casse `echo "$" ` et ca corrige `echo "$PWD" `, le pourquoi du comment je sais pas, mon but est d'ameliorer la gestion d'erreur ici :

```
Minishell on  errors-v2 [!?] 
❯ diff 98_incoming.txt 98.txt 
18,20c18
< Test   7: ❌ echo "$PWD" 
< mini output = ()
< bash output = (/home/user/Minishell/minishell_tester)
---
> Test   7: ✅ echo "$PWD" 
58c56,58
< Test  17: ✅ echo "$" 
---
> Test  17: ❌ echo "$" 
> mini output = ()
> bash output = ($)
164c164
< mini exit code = 0
---
> mini exit code = 255
176,177d175
< mini error = ( numeric argument required exit)
< bash error = ()
```