### PR TITLE
Ajoute les signaux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: agaley <agaley@student.42lyon.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/07/22 01:40:01 by akhellad          #+#    #+#              #
-#    Updated: 2023/08/01 01:35:34 by agaley           ###   ########lyon.fr    #
+#    Updated: 2023/08/04 01:25:16 by agaley           ###   ########lyon.fr    #
 #                                                                              #
 # **************************************************************************** #
 
@@ -42,6 +42,7 @@ SRCS    = main.c \
 		  cd_built.c \
 		  env_built.c \
 		  exit_built.c \
+		  signals.c
 
 OBJS    = $(addprefix $(OBJS_DIR),$(SRCS:.c=.o))
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: akhellad <akhellad@student.42.fr>          +#+  +:+       +#+        */
+/*   By: agaley <agaley@student.42lyon.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/22 01:41:30 by akhellad          #+#    #+#             */
-/*   Updated: 2023/07/28 21:48:43 by akhellad         ###   ########.fr       */
+/*   Updated: 2023/08/04 01:31:54 by agaley           ###   ########lyon.fr   */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,7 @@
 # include <readline/history.h>
 # include <limits.h>
 # include <errno.h>
+# include <signal.h>
 
 typedef enum s_tokens
 {
@@ -172,6 +173,9 @@ int				check_double_quotes(char *str, int i, int *quotes_nbr, \
 									int quotes);
 char			*del_quotes(char *str, char c);
 int				quotes(int i, char *str, char del);
+
+/*signals.c*/
+void			signal_init(void);
 
 /*spaces.c*/
 int				skip_spaces(char *str, int i);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: agaley <agaley@student.42lyon.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/22 01:41:27 by akhellad          #+#    #+#             */
-/*   Updated: 2023/08/01 01:43:34 by agaley           ###   ########lyon.fr   */
+/*   Updated: 2023/08/04 01:29:45 by agaley           ###   ########lyon.fr   */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,6 +55,7 @@ int	main(int ac, char **av, char **env)
 		dprintf(STDERR_FILENO, ": No such file or directory\n");
 		return (EXIT_FAILURE);
 	}
+	signal_init();
 	infos.envp = ft_arrdup(env);
 	init_pwd(&infos);
 	init_infos(&infos);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: akhellad <akhellad@student.42.fr>          +#+  +:+       +#+        */
+/*   By: agaley <agaley@student.42lyon.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/22 01:41:27 by akhellad          #+#    #+#             */
-/*   Updated: 2023/07/28 04:59:33 by akhellad         ###   ########.fr       */
+/*   Updated: 2023/08/01 01:43:34 by agaley           ###   ########lyon.fr   */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,12 +50,14 @@ int	main(int ac, char **av, char **env)
 
 	if (ac != 1 || av[1])
 	{
-		printf("Too many arguments\n");
-		return (0);
+		dprintf(STDERR_FILENO, "minish: ");
+		dprintf(STDERR_FILENO, "%s", av[1]);
+		dprintf(STDERR_FILENO, ": No such file or directory\n");
+		return (EXIT_FAILURE);
 	}
 	infos.envp = ft_arrdup(env);
 	init_pwd(&infos);
 	init_infos(&infos);
 	main_loop(&infos);
-	return (0);
+	return (EXIT_SUCCESS);
 }

--- a/srcs/signals.c
+++ b/srcs/signals.c
@@ -1,0 +1,28 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   signals.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: agaley <agaley@student.42lyon.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/08/04 01:05:18 by agaley            #+#    #+#             */
+/*   Updated: 2023/08/04 01:30:30 by agaley           ###   ########lyon.fr   */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../includes/minishell.h"
+
+static void	signal_handler(int signum)
+{
+	signal(signum, signal_handler);
+	if (signum == SIGQUIT)
+		return ;
+	if (signum == SIGINT)
+		printf("TODO : relancer le prompt minishell>\n");
+}
+
+void	signal_init(void)
+{
+	signal(SIGQUIT, signal_handler);
+	signal(SIGINT, signal_handler);
+}


### PR DESCRIPTION
ça catch les SIGINT (ctrl + c) et les SIGQUIT (ctrl + \)

1. Problème avec le SIGQUIT, bash ne fait rien du tout (comportement attendu) alors que minishell affiche `^\              ` et une sorte de tabulation derrière : 

```
Minishell on  signals [?] took 3s 
❯ bash

Minishell on  signals [?] 
❯ exit
exit

Minishell on  signals [?] took 4s 
❯ ./minishell
minishell> ^\              exit
free(): invalid pointer
Aborted (core dumped)
```

Comment bloquer ça ? SIGQUIT est catch par le signal_handler L18 de signals.c


2. Pour implémenter le crtl+c il faudrait retourner à nouveau le prompt depuis L21 de signals.c

Comment faire ?